### PR TITLE
Create data dir for bnb data unless it exists

### DIFF
--- a/bnb/getBNBData.sh
+++ b/bnb/getBNBData.sh
@@ -1,11 +1,13 @@
 #!/bin/bash
 
-cd /var/www/Tools/BNBDaten
+BNB_DATADIR="/var/www/Tools/BNBDaten"
+mkdir -pv "$BNB_DATADIR"
+cd "$BNBDaten"
 
 wget -r -np -l 1 -A zip http://www.bl.uk/bibliographic/bnbrdfxml.html
 
-for f in /var/www/Tools/BNBDaten/www.bl.uk/bibliographic/bnbrdf/*.zip
-do 
-unzip -o $f
-rm $f
+for f in $BNB_DATADIR/www.bl.uk/bibliographic/bnbrdf/*.zip
+do
+    unzip -o "$f"
+    rm "$f"
 done


### PR DESCRIPTION
Create the data dir with `mkdir -p` unless it exists.

Signed-off-by: Konstantin Baierer <konstantin.baierer@bib.uni-mannheim.de>