### PR TITLE
Update hebis.php to new Z39.50 interface

### DIFF
--- a/isbn/conf.example.php
+++ b/isbn/conf.example.php
@@ -42,12 +42,11 @@ define('GBV_ELEMENTSET',    'f');
 
 
 //HEBIS = Hessisches BibliotheksInformationsSystem
-//http://www.hebis.de/de/1service/z3950/z39_zugang_index.php
-define('HEBIS_URL',         'tolk.hebis.de:20211/hebis');
-define('HEBIS_USER',        '');//TODO look up
-define('HEBIS_PASSWORD',    '');//TODO look up
+//http://www.hebis.de/de/1service/z3950/z3950_index.php
+//http://www.hebis.de/de/1service/z3950/z3950_zugang_neu2016.php
+define('HEBIS_URL',         'tolk.hebis.de:22000/hebis');
 define('HEBIS_SYNTAX',      'marc21');
-define('HEBIS_ELEMENTSET',  'F');
+define('HEBIS_ELEMENTSET',  'xf');
 
 
 //NEBIS

--- a/isbn/hebis.php
+++ b/isbn/hebis.php
@@ -28,11 +28,10 @@
 
 include 'lib.php';
 
-$id = yaz_connect(HEBIS_URL, array("user" => HEBIS_USER, "password" => HEBIS_PASSWORD));
+$id = yaz_connect(HEBIS_URL);
 yaz_syntax($id, HEBIS_SYNTAX);//
 yaz_range($id, 1, 10);
 yaz_element($id, HEBIS_ELEMENTSET); //
-
 
 if (isset($_GET['ppn'])) {
     $ppn = trim($_GET['ppn']);
@@ -52,7 +51,6 @@ if (isset($_GET['isbn'])) {
     // @attr 5=100 -> no truncation, ist aber Standardeinstellung, kann daher auch weg
 }
 
-
 yaz_wait();
 $error = yaz_error($id);
 if (!empty($error)) {
@@ -61,76 +59,19 @@ if (!empty($error)) {
     echo "Additional Error Information: " . yaz_addinfo($id);
 }
 
-
 $outputString = "<?xml version=\"1.0\"?>\n";
 $outputString .= "<collection>\n";
 $outputArray = [];
 
 for ($p = 1; $p <= yaz_hits($id); $p++) {
-    yaz_syntax($id, "marc21");//In der for-Schlaufe muss von Pica-Format wieder auf marc21 umgeschaltet werden
-    $record = yaz_record($id, $p, "xml;charset=iso5426,utf8");//Umwandlung in XML
+    $record = yaz_record($id, $p, "xml");//Umwandlung in XML
+    //namespace löschen
     $record = str_replace('xmlns="http://www.loc.gov/MARC21/slim"', '', $record);
-    $recordXml = simplexml_load_string("<?xml version=\"1.0\"?>".$record);//Umwandlung in ein SimpleXMLElement Objekt
-
-    //NACHBEARBEITUNG:
-    //Nachbearbeitung noetig, da leider nicht alle Daten im MARC21 Format liegen.
-    //Z.B. RVK, DDC, ...
-    //Daher wird vom PICA Format ausgehend, diese Daten gesucht.
-    yaz_syntax($id, "mab2");//mab2 ist Pica-Format
-    $recordPica = yaz_record($id, $p, "string");//render;charset=iso5426,utf8
-    $recordPica = strtr($recordPica, "\x9f", "$");//Unterfeld
-
-    //DDC im HEBIS
-    //" �eDDCoclc�a006.6" = 209f654444436f636c639f613030362e36 hex
-    preg_match_all('/045[FB] .*\$a(\d{3}\.?\d*)/m', $recordPica, $description);
-    for ($i = 0; $i < count($description[1]); $i++) {
-        $field = $recordXml->addChild("datafield");
-        $field->addAttribute('tag', '082');
-        $field->addAttribute('ind1', ' ');
-        $field->addAttribute('ind2', ' ');
-        $subfield = $field->addChild("subfield", $description[1][$i]);
-        $subfield->addAttribute('code', 'a');
-    }
-
-    //RVK im HEBIS
-    //045Z $aST 151
-    preg_match_all('/045Z \$a([^\<\n\|]*)/', $recordPica, $description);
-    for ($i = 0; $i < count($description[1]); $i++) {
-        $field = $recordXml->addChild("datafield");
-        $field->addAttribute('tag', '084');
-        $field->addAttribute('ind1', ' ');
-        $field->addAttribute('ind2', ' ');
-        $subfield = $field->addChild("subfield", $description[1][$i]);
-        $subfield->addAttribute('code', 'a');
-        $subfield2 = $field->addChild("subfield", 'rvk');
-        $subfield2->addAttribute('code', '2');
-    }
-
-    //Schlagwörter
-    //041A/09 $9125282621$VTs1$04806620-5$aAgile Softwareentwicklung
-    //044K $9223456969$VTs1$07702558-1$aVisual C sharp 2010
-    //041A/07 $af Kongress ==> funktioniert mit RegExp unten nicht
-    //041A/08 $ag Burgas <2011> ==> funktioniert mit RegExp unten nicht
-    preg_match_all('/04(4K|1A).*\$0([^\$\<\n]*).*\$a([^\$\<\n]*)/', $recordPica, $description);
-    for ($i = 0; $i < count($description[2]); $i++) {
-        $field = $recordXml->addChild("datafield");
-        $field->addAttribute('tag', '689');
-        $field->addAttribute('ind1', '0');
-        $field->addAttribute('ind2', '0');
-        $subfield = $field->addChild("subfield", '(DE-588)'.$description[2][$i]);
-        $subfield->addAttribute('code', '0');
-        $subfield2 = $field->addChild("subfield", $description[3][$i]);
-        $subfield2->addAttribute('code', 'a');
-    }
-
-    //AUSGABE DES ANGEREICHTERTEN RECORD
-    //erste Zeile abschneiden, da xml Deklaration bereits in der collection erledigt wurde.
-    $outputString .=  str_replace('<?xml version="1.0"?>', "", $recordXml->asXML());
-    array_push($outputArray, str_replace('<?xml version="1.0"?>', "", $recordXml->asXML()));
+    $outputString .=  $record;
+    array_push($outputArray, $record);
 }
 $outputString .=  "</collection>";
 yaz_close($id);
-
 
 $map = $standardMarcMap;
 $map['bestand'] = '//datafield[@tag="924"]/subfield[@code="b"]';
@@ -139,9 +80,7 @@ $map['bestand'] = '//datafield[@tag="924"]/subfield[@code="b"]';
 if (!isset($_GET['format'])) {
     header('Content-type: text/xml');
     echo $outputString;
-
 } else if ($_GET['format']=='json') {
-
     $outputXml = simplexml_load_string($outputString);
     $outputMap = performMapping($map, $outputXml);
     $outputIndividualMap = [];


### PR DESCRIPTION
This solves #64. The new endpoint will return
* directly UTF-8
* only MARC21
* all information also RVK, DDC, SW
* no password is needed

=> Thus, we can remove some of the previously necessary
postprocessing steps, which simplifies the code.