### PR TITLE
Updated the hyperlinks to ebook packages

### DIFF
--- a/isbn/rendering.js
+++ b/isbn/rendering.js
@@ -45,7 +45,7 @@ function renderSigel(sigelArray){
 	var trenner = ", ";
 	for (var i=0; i<sigelArray.length; i++) { 
 		if (sigelArray[i].startsWith("ZDB-")) { // render Sigel starting with ZDB- as links
-			sigelMitZDBAlsLinks += '<a href="http://dispatch.opac.dnb.de/DB=1.2/CMD?ACT=SRCHA&IKT=8521&SRT=LST_os&TRM='+ sigelArray[i] + '" '  + 'target="_blank">' + sigelArray[i] + '</a>';
+			sigelMitZDBAlsLinks += '<a href="http://sigel.staatsbibliothek-berlin.de/nc/suche/?isil='+ sigelArray[i] + '" '  + 'target="_blank">' + sigelArray[i] + '</a>';
 		} else { // render other Sigel normally
 			sigelMitZDBAlsLinks += sigelArray[i];
 		}


### PR DESCRIPTION
I've updated the hyperlinks of ebook packages to `http://sigel.staatsbibliothek-berlin.de/nc/suche/?isil=` instead of `http://dispatch.opac.dnb.de/DB=1.2/CMD?ACT=SRCHA&IKT=8521&SRT=LST_os&TRM=`

**Example**
Now links to `http://sigel.staatsbibliothek-berlin.de/nc/suche/?isil=ZDB-23-DEM` instead of `http://dispatch.opac.dnb.de/DB=1.2/CMD?ACT=SRCHA&IKT=8521&SRT=LST_os&TRM=ZDB-23-DGG`