### PR TITLE
Update Dockerfile because php:apache updated

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -10,7 +10,7 @@ FROM php:apache
 ENV JQUERY 3.2.1
 ENV CLIPBOARD 1.7.1
 
-RUN apt-get update && apt-get install -y yaz libyaz4-dev php5-dev php-pear wget unzip
+RUN apt-get update && apt-get install -y yaz libyaz4-dev php-dev php-pear wget unzip
 
 RUN pecl install yaz
 RUN docker-php-ext-enable yaz

--- a/Dockerfile
+++ b/Dockerfile
@@ -10,10 +10,9 @@ FROM php:apache
 ENV JQUERY 3.2.1
 ENV CLIPBOARD 1.7.1
 
-RUN apt-get update && apt-get install -y yaz libyaz4-dev php-dev php-pear wget unzip
-
-RUN pecl install yaz
-RUN docker-php-ext-enable yaz
+RUN apt-get update && apt-get install -y yaz libyaz4-dev wget unzip \
+    && pecl install yaz \
+    && docker-php-ext-enable yaz
 
 RUN mkdir malibu
 WORKDIR malibu


### PR DESCRIPTION
The php:apache now uses also Debian 7 with PHP 7 and therfore
we need to replace the package php5-dev with php-dev.

See also #85.