### PR TITLE
K10plus SRU Abfrage optimieren

### DIFF
--- a/isbn/k10plus.php
+++ b/isbn/k10plus.php
@@ -20,33 +20,34 @@
  * k10plus?isbn=ISBN&format=json
  * k10plus?ppn=PPN&format=json
  *   Ausgabe erfolgt als JSON
+ * k10plus?swn=SWN
+ *   SWN ist die alte SWB PPN
  *
  * Sucht übergebene ISBN bzw. PPN im K10PLus-Katalog
  * und gibt maximal 10 Ergebnisse als MARCXML zurück
  * bzw. als JSON.
+ *
+ * Info zur SRU-Schnittstelle: https://wiki.k10plus.de/display/K10PLUS/SRU
  */
 
 include 'lib.php';
 
-if (isset($_GET['ppn'])) {
-    $ppn = trim($_GET['ppn']);
-    $suchString = 'pica.ppn=' . $ppn;
-    //TODO Können wir hier auch nach früheren SWB PPNs mitsuchen?
-}
-
-/*
-https://wiki.k10plus.de/display/K10PLUS/SRU
-
-http://sru.k10plus.de/gvk?version=1.1&operation=searchRetrieve&query=9781470435172&maximumRecords=10&recordSchema=marcxml
-*/
-
-$urlBase = 'http://sru.k10plus.de/gvk?version=1.1&operation=searchRetrieve&query=';
+$urlBase = 'https://sru.k10plus.de/opac-de-627?version=1.1&operation=searchRetrieve&query=';
 $urlSuffix = '&maximumRecords=10&recordSchema=marcxml';
 
 if (isset($_GET['isbn'])) {
     $n = trim($_GET['isbn']);
     $nArray = explode(",", $n);
-    $suchString = 'pica.isb=' . implode('+OR+pica.isb=', $nArray);
+    $suchString = 'pica.isb%3D' . implode('+OR+pica.isb=', $nArray);
+}
+if (isset($_GET['ppn'])) {
+    $ppn = trim($_GET['ppn']);
+    $suchString = 'pica.ppn%3D' . $ppn;
+}
+
+if (isset($_GET['swn'])) {
+    $ppn = trim($_GET['swn']); // alte SWB PPN
+    $suchString = 'pica.swn%3D' . $ppn;
 }
 
 $result = file_get_contents($urlBase . $suchString . $urlSuffix);

--- a/isbn/suche.html
+++ b/isbn/suche.html
@@ -143,7 +143,7 @@ function isbnEingabe(n) {
     var suchString = n.replace(/,/g, ' or ');
     $('#status').append("Gesucht wurden ISBN " + suchString);
     $('#suche'+'SWB').html('<a href="http://swb.bsz-bw.de/DB=2.1/SET=1/TTL=1/CMD?ACT=SRCHA&IKT=1007&TRM='+suchString+'" target="_blank">SWB</a>');
-    $('#suche'+'K10PLUS').html('<a href="https://kxp.k10plus.de/DB=2.1/SET=1/TTL=1/CMD?ACT=SRCHA&IKT=7&TRM='+suchString+'" target="_blank">K10PLUS (GVK)</a>');
+    $('#suche'+'K10PLUS').html('<a href="https://kxp.k10plus.de/DB=2.0/SET=1/TTL=1/CMD?ACT=SRCHA&IKT=7&TRM='+suchString+'" target="_blank">K10PLUS</a>');
     $('#suche'+'HEBIS').html('<a href="http://cbsopac.rz.uni-frankfurt.de/DB=2.1/SET=1/TTL=1/CMD?ACT=SRCHA&IKT=8520&TRM='+nArray[0]+'" target="_blank">HEBIS</a>');
     $('#suche'+'B3KAT').html('<a href="https://opacplus.bib-bvb.de/TouchPoint_touchpoint/start.do?Query=-1%3D%22' + nArray[0] + '%22&Language=De&SearchProfile=" target="_blank">B3KAT</a>');
     $('#suche'+'HBZ').html('<a href="http://okeanos-www.hbz-nrw.de/F/?FUNC=find-c&CCL_TERM=+IBN=%28'+nArray[0]+'" target="_blank">HBZ</a>');
@@ -366,8 +366,8 @@ function isbnEingabe(n) {
         <td id="ddcSWB"></td>
         <td id="swSWB"></td>
     </tr>
-	<tr>
-        <td><div id="sucheK10PLUS">K10PLUS (GVK)</div><div id="bestandK10PLUS"></div></td>
+    <tr>
+        <td><div id="sucheK10PLUS">K10PLUS</div><div id="bestandK10PLUS"></div></td>
         <td id="rvkK10PLUS"></td>
         <td id="ddcK10PLUS"></td>
         <td id="swK10PLUS"></td>


### PR DESCRIPTION
- anstatt gvk wird opac-de-627 als Datenbank verwendet
  (fixes #116) und auch Link in den K10plus angepasst
- Suchstring wird urlencoded
- Abfragen über https
- für die alten SWB-PPNs wird eine weitere Suchmöglichkeit geschaffen