### PR TITLE
Veraltete RVK-Stellen markieren und Fehlermeldung anzeigen

### DIFF
--- a/isbn/malibu_light.css
+++ b/isbn/malibu_light.css
@@ -30,6 +30,12 @@ body {
 }
 
 
+/* BESUCHTE LINKS */
+
+a:visited {
+  color: #606060;
+}
+
 
 /* PADDING FÜR SEKTIONEN */
 
@@ -289,7 +295,9 @@ input, select {
 
 }
 
-
+.rvkError, .rvkError:visited {
+  color: red;
+}
 
 
 

--- a/isbn/malibu_light.css
+++ b/isbn/malibu_light.css
@@ -271,6 +271,10 @@ input, select {
   color: #F1EDEB;
 }
 
+.verbuendeUeber th {
+  text-align: left;
+}
+
 #verbuende tr:nth-child(2n+3) {
   background-color: #F1EDEB;
 }

--- a/isbn/rendering.js
+++ b/isbn/rendering.js
@@ -67,10 +67,15 @@ function addBenennung(index, element) {
     //z.B. https://rvk.uni-regensburg.de/api/json/ancestors/SU+680?jsonp=wrapper
     var rvkApi = 'https://rvk.uni-regensburg.de/api/json/ancestors/' + className.replace('-', '+') + '?jsonp=?';
     $.getJSON(rvkApi, function(json) {
-        if (json.node.ancestor) {//Benennung des Knoten + Benennung des Vorfahrens
-            $('.'+className).attr("title", json.node.benennung + ' <-- ' + json.node.ancestor.node.benennung);
-        } else {//Benennung des Knoten
-            $('.'+className).attr("title", json.node.benennung);
+        if ("node" in json) {
+            if (json.node.ancestor) {//Benennung des Knoten + Benennung des Vorfahrens
+                $('.'+className).attr("title", json.node.benennung + ' <-- ' + json.node.ancestor.node.benennung);
+            } else {//Benennung des Knoten
+                $('.'+className).attr("title", json.node.benennung);
+            }
+        } else if ("error-message" in json) {
+            $('.'+className).attr("title", "ERROR: "+json['error-message']);
+            $('.'+className).addClass("rvkError");
         }
     });
 }


### PR DESCRIPTION
Insbesondere bei veralteten Notationen #87 liefert die RVK-API eine
ensprechende Fehlermeldung. Diese wird jetzt angezeigt und die
entsprechende RVK-Stelle farblich hervorgehoben.

Zudem werden besuchte URLs jetzt wieder leicht unterschiedlich
farblich angezeigt (grau anstatt schwarz).