### PR TITLE
Falsche Bestandsausgabe man-sru.php korrigiert + ISBNs der Vor-/Folgeauflage anzeigen

### DIFF
--- a/isbn/lib.php
+++ b/isbn/lib.php
@@ -46,8 +46,11 @@ $standardMarcMap = array(
         'value' => './subfield[@code="a" or @code="t"]',
         'additional' => './subfield[@code="9" or @code="g"]',
         'key' => './subfield[@code="0" and contains(text(), "(DE-588)")]'
-        ),
-        'produktSigel' => '//datafield[@tag="912" and not(@ind2="7")]/subfield[@code="a"]'
+    ),
+    'produktSigel' => '//datafield[@tag="912" and not(@ind2="7")]/subfield[@code="a"]',
+    'vorauflage' => '//datafield[@tag="780"]/subfield[@code="z"]',
+    'folgeauflage' => '//datafield[@tag="785"]/subfield[@code="z"]',
+    'andererelation' => '//datafield[@tag="787" or @tag="775"]/subfield[@code="z"]'
 );
 
 $standardMabMap = array(

--- a/isbn/malibu_light.css
+++ b/isbn/malibu_light.css
@@ -43,7 +43,7 @@ a:visited {
   padding: 0em 10em;
 }
 
-#ausgaben, #pda, #bestandsabgleich div, #weiteres, #links, #status, #titel, #verkaufsinfo {
+#ausgaben, #relationen, #pda, #bestandsabgleich div, #weiteres, #links, #status, #titel, #verkaufsinfo {
   padding: 1em 0em;
 }
 

--- a/isbn/man-sru.php
+++ b/isbn/man-sru.php
@@ -80,9 +80,18 @@ $outputString .= "<collection>\n";
 $outputArray = [];
 
 foreach ($records as $record) {
-
-    $outputString .= $doc->saveXML($record);
-    array_push($outputArray, $doc->saveXML($record));
+    // Filter out any other results which contain the ISBN but not in the 020 field
+    $foundMatch = false;
+    $foundIsbns = $xpath->query('.//datafield[@tag="020"]/subfield', $record);
+    foreach ($foundIsbns as $foundValue) {
+        if (in_array($foundValue->nodeValue, $nArray)) {
+            $foundMatch = true;
+        }
+    }
+    if ($foundMatch) {
+        $outputString .= $doc->saveXML($record);
+        array_push($outputArray, $doc->saveXML($record));
+    }
 }
 $outputString .= "</collection>";
 

--- a/isbn/man-sru.php
+++ b/isbn/man-sru.php
@@ -83,9 +83,17 @@ foreach ($records as $record) {
     // Filter out any other results which contain the ISBN but not in the 020 field
     $foundMatch = false;
     $foundIsbns = $xpath->query('.//datafield[@tag="020"]/subfield', $record);
-    foreach ($foundIsbns as $foundValue) {
-        if (in_array($foundValue->nodeValue, $nArray)) {
-            $foundMatch = true;
+    foreach ($foundIsbns as $foundNode) {
+        $foundValue = $foundNode->nodeValue;
+        foreach ($nArray as $queryValue) {
+            $testString = str_replace("-", "", $queryValue);
+            if (strlen($testString) == 13) {
+                // Delete the 978-prefix and the check value at the end for ISBN13
+                $testString = substr($testString, 3, -1);
+            }
+            if (strpos(str_replace("-", "", $foundValue), $testString) !== false) {
+                $foundMatch = true;
+            }
         }
     }
     if ($foundMatch) {

--- a/isbn/man-sru.php
+++ b/isbn/man-sru.php
@@ -80,13 +80,13 @@ $outputString .= "<collection>\n";
 $outputArray = [];
 
 foreach ($records as $record) {
-    // Filter out any other results which contain the ISBN but not in the 020 field
+    // Filter out any other results which contain the ISBN but not in the 020 or 776 field
     $foundMatch = false;
     $foundIsbns = $xpath->query('.//datafield[@tag="020" or @tag="776"]/subfield', $record);
     foreach ($foundIsbns as $foundNode) {
         $foundValue = $foundNode->nodeValue;
         foreach ($nArray as $queryValue) {
-            $testString = str_replace("-", "", $queryValue);
+            $testString = preg_replace('/[^0-9xX]/', '', $queryValue);
             if (strlen($testString) == 13) {
                 // Delete the 978-prefix and the check value at the end for ISBN13
                 $testString = substr($testString, 3, -1);
@@ -94,7 +94,7 @@ foreach ($records as $record) {
                 // Delete check value at the end for ISBN10
                 $testString = substr($testString, 0, -1);
             }
-            if (strpos(str_replace("-", "", $foundValue), $testString) !== false) {
+            if (strpos(preg_replace('[^0-9xX]', '', $foundValue), $testString) !== false) {
                 $foundMatch = true;
             }
         }

--- a/isbn/man-sru.php
+++ b/isbn/man-sru.php
@@ -82,7 +82,7 @@ $outputArray = [];
 foreach ($records as $record) {
     // Filter out any other results which contain the ISBN but not in the 020 field
     $foundMatch = false;
-    $foundIsbns = $xpath->query('.//datafield[@tag="020"]/subfield', $record);
+    $foundIsbns = $xpath->query('.//datafield[@tag="020" or @tag="776"]/subfield', $record);
     foreach ($foundIsbns as $foundNode) {
         $foundValue = $foundNode->nodeValue;
         foreach ($nArray as $queryValue) {
@@ -90,6 +90,9 @@ foreach ($records as $record) {
             if (strlen($testString) == 13) {
                 // Delete the 978-prefix and the check value at the end for ISBN13
                 $testString = substr($testString, 3, -1);
+            } elseif (strlen($testString) == 10) {
+                // Delete check value at the end for ISBN10
+                $testString = substr($testString, 0, -1);
             }
             if (strpos(str_replace("-", "", $foundValue), $testString) !== false) {
                 $foundMatch = true;

--- a/isbn/rendering.js
+++ b/isbn/rendering.js
@@ -96,6 +96,20 @@ function renderDDC(ddcArray) {
     }
 }
 
+
+function renderRelationen(relationenArray) {
+    if (typeof relationenArray === 'string') {
+        return relationenArray;
+    } else {
+        for (var i=0; i<relationenArray.length; i++) {
+            var rel = relationenArray[i];
+            relationenArray[i] = '<a href="./suche.html?isbn=' + rel + '" target="_blank">' + rel + '</a>';
+        }
+        return relationenArray.join(', ');
+    }
+}
+
+
 var paketInfoMap = [];// kann um die lokalen Pakete ergänzt werden
 var overallPaketSigel = [];//alle bereits gefunden Sigel werden in einer Liste gespeichert
 

--- a/isbn/suche.html
+++ b/isbn/suche.html
@@ -373,6 +373,22 @@ function isbnEingabe(n) {
         if(data.produktSigel && data.produktSigel.length>0) {
             $('#pda').append( renderPS(data.produktSigel) );
         }
+
+        var relationenText = "";
+        if(data.vorauflage && data.vorauflage.length>0) {
+            relationenText += "Vorauflage: " + renderRelationen(data.vorauflage);
+        }
+        if(data.folgeauflage && data.folgeauflage.length>0) {
+            relationenText += relationenText.length>0 ? " | " : "";
+            relationenText += "Folgeauflage: " + renderRelationen(data.folgeauflage);
+        }
+        if(data.andererelation && data.andererelation.length>0) {
+            relationenText += relationenText.length>0 ? " | " : "";
+            relationenText += "Andere Relation: " + renderRelationen(data.andererelation);
+        }
+        if(relationenText.length>0) {
+            $('#relationen').html(relationenText.trim());
+        }
         
         $('#links').append( renderLinks(data.links) );
         if (data.dnbNr.length>0) {
@@ -506,6 +522,9 @@ function isbnEingabe(n) {
 </div>
 
 <div id='bestandsabgleich'>
+</div>
+
+<div id='relationen'>
 </div>
 
 <div id='pda'>


### PR DESCRIPTION
Bei Werken mit verknüpften Vor- oder Nachfolgern inklusive ISBN
wurden diese fälschlicherweise ebenfalls als Bestand angezeigt,
da in der SRU-Schnittstelle eine Alle-Felder-Suche gemacht wurde.
Z.B. https://data.bib.uni-mannheim.de/malibu/isbn/man-sru.php?isbn=9783406748752
Die zusätzliche Filterung behebt dieses Problem.