### PR TITLE
Add Installation notes for Debian 11

### DIFF
--- a/INSTALL.md
+++ b/INSTALL.md
@@ -12,6 +12,7 @@ an environment for code development.
   * [For Debian 8 (Apache 2.4)](#for-debian-8-apache-24)
   * [For Debian 9 (Apache 2.4 and PHP 7.0)](#for-debian-9-apache-24-and-php-70)
   * [For Debian 10 (Apache 2.4 and PHP 7.3)](#for-debian-10-apache-24-and-php-73)
+  * [For Debian 11 (Apache 2.4 and PHP 7.4)](#for-debian-11-apache-24-and-php-74)
   * [For UBUNTU 18.04 LTS (Apache 2.4 and PHP 7.4)](#for-ubuntu-1804-lts-apache-24-and-php-74)
 * [Initializing and Costumizing](#initializing-and-costumizing)
 * [Configuration for code development](#configurations-for-code-development)
@@ -80,6 +81,40 @@ You need the php library <a href="http://php.net/manual/en/book.yaz.php">yaz</a>
 * <code>apt-get install yaz libyaz-dev php-dev php-pear libapache2-mod-php</code> (maybe you already have some packages)
 * <code>pecl install yaz</code>
 * create new file `/etc/php/7.3/mods-available/yaz.ini` and add
+```sh
+; configuration for php YAZ module
+; priority=20
+extension=yaz.so
+```
+* enable the YAZ module
+```sh
+phpenmod yaz
+```
+* restart Apache2 server
+```sh
+systemctl restart apache2
+```
+
+### For Debian 11 (Apache 2.4 and PHP 7.4)
+Basically the same as for Debian 10 BUT **yaz-config** is not available anymore, so the installation step <code>pecl install yaz</code> will fail.
+
+You need the php library <a href="http://php.net/manual/en/book.yaz.php">yaz</a> on the server.
+
+* <code>apt-get install yaz php-dev php-pear libapache2-mod-php7.4</code> (maybe you already have some packages)
+
+
+* <code>wget -O yaz.tar.gz http://pecl.php.net/get/yaz</code>
+* <code>tar -zxvf yaz.tar.gz</code>
+* <code>cd yaz-<version></code>
+* replace file `config.m4` with `extra/config.m4` from this repository
+* <code>phpize</code>
+* <code>./configure</code>
+* <code>make</code>
+* <code>make test</code>
+* <code>make install</code>
+
+
+* create new file `/etc/php/7.4/mods-available/yaz.ini` and add
 ```sh
 ; configuration for php YAZ module
 ; priority=20

--- a/extra/config.m4
+++ b/extra/config.m4
@@ -1,0 +1,42 @@
+PHP_ARG_WITH(yaz,for YAZ support,
+[  --with-yaz[=DIR]        Include YAZ support (ANSI/NISO Z39.50).
+                          DIR is the YAZ bin install directory.])
+
+
+if test "$PHP_YAZ" != "no"; then
+  if `pkg-config --exists yaz`; then
+    AC_DEFINE(HAVE_YAZ,1,[Whether you have YAZ])
+    AC_MSG_CHECKING([for YAZ version via pkg-config])
+    if `pkg-config --atleast-version=3.0.2 yaz`; then
+      AC_MSG_RESULT([$YAZVERSION])
+    else
+      AC_MSG_ERROR([YAZ version 3.0.2 or later required.])
+    fi
+
+    prefix=`pkg-config --variable=prefix yaz`
+    exec_prefix=`pkg-config --variable=exec_prefix yaz`
+    libdir=`pkg-config --variable=libdir yaz`
+
+    YAZLIB=`pkg-config --libs yaz`
+    AC_MSG_NOTICE([YAZLIB: $YAZLIB])
+    for c in $YAZLIB; do
+      case $c in
+       -L*)
+         dir=`echo $c|cut -c 3-|sed 's%/\.libs%%g'`
+         PHP_ADD_LIBPATH($dir,YAZ_SHARED_LIBADD)
+        ;;
+       -l*)
+         lib=`echo $c|cut -c 3-`
+         PHP_ADD_LIBRARY($lib,,YAZ_SHARED_LIBADD)
+        ;;
+      esac
+    done
+    YAZINC=`pkg-config --cflags yaz`
+    AC_MSG_NOTICE([YAZINC: $YAZINC])
+    PHP_EVAL_INCLINE($YAZINC)
+    PHP_NEW_EXTENSION(yaz, php_yaz.c, $ext_shared)
+    PHP_SUBST(YAZ_SHARED_LIBADD)
+  else
+    AC_MSG_ERROR([YAZ not found (missing $yazconfig)])
+  fi
+fi


### PR DESCRIPTION
Debian 11 does not provide yaz-config any more, so compiling (`configure`) php-yaz fails.

As a work-around the yaz configuration can be obtained via pkg-config.