### PR TITLE
Neue Schnittstelle für Schweizer Katalog angebunden

### DIFF
--- a/isbn/suche.html
+++ b/isbn/suche.html
@@ -305,7 +305,7 @@ function isbnEingabe(n) {
     $('#suche'+'HEBIS').html('<a href="http://cbsopac.rz.uni-frankfurt.de/DB=2.1/SET=1/TTL=1/CMD?ACT=SRCHA&IKT=8520&TRM='+nArray[0]+'" target="_blank">HEBIS</a>');
     $('#suche'+'B3KAT').html('<a href="https://opacplus.bib-bvb.de/TouchPoint_touchpoint/start.do?Query=-1%3D%22' + nArray[0] + '%22&Language=De&SearchProfile=" target="_blank">B3KAT</a>');
     $('#suche'+'HBZ').html('<a href="http://okeanos-www.hbz-nrw.de/F/?FUNC=find-c&CCL_TERM=+IBN=%28'+nArray[0]+'" target="_blank">HBZ</a>');
-    $('#suche'+'SWISS').html('<a href="https://swisscovery.slsp.ch/discovery/search?query=isbn,contains,'+nArray[0]+',AND&tab=41SLSP_NETWORK&search_scope=DN_and_CI&vid=41SLSP_NETWORK:VU1_UNION&mode=advanced&offset=0" target="_blank">SWISS</a>');
+    $('#suche'+'SWISS').html('<a href="https://swisscovery.slsp.ch/discovery/search?query=isbn,contains,'+nArray[0]+',AND&tab=41SLSP_NETWORK&search_scope=DN_and_CI&vid=41SLSP_NETWORK:VU1_UNION&mode=advanced&offset=0" target="_blank">swisscovery</a>');
     $('#suche'+'OBVSG').html('<a href="http://search.obvsg.at/primo_library/libweb/action/search.do?fn=search&ct=search&initialSearch=true&mode=Basic&tab=default_tab&indx=1&dum=true&srt=rank&vid=OBV&tb=t&vl%28freeText0%29='+nArray[0]+'" target="_blank">OBVSG</a>');
 
     
@@ -490,7 +490,7 @@ function isbnEingabe(n) {
                     <option type="radio" name="eingabeVerbund" value="B3KAT">B3KAT
                     <option type="radio" name="eingabeVerbund" value="HEBIS">HEBIS
                     <option type="radio" name="eingabeVerbund" value="HBZ">HBZ
-                    <option type="radio" name="eingabeVerbund" value="SWISS">SWISS
+                    <option type="radio" name="eingabeVerbund" value="SWISS">swisscovery
                     <option type="radio" name="eingabeVerbund" value="OBVSG">OBVSG
                 </select>
                 <input class="button" type="submit" value="Submit">
@@ -577,7 +577,7 @@ function isbnEingabe(n) {
         <td id="ddcHEBIS" class="ddc"></td>
         <td id="swHEBIS"></td>
 	<tr>
-        <td><div id="sucheSWISS">swissbib</div><small><div id="bestandSWISS"></div></small></td>
+        <td><div id="sucheSWISS">swisscovery</div><small><div id="bestandSWISS"></div></small></td>
         <td id="rvkSWISS" class="rvk"></td>
         <td id="ddcSWISS" class="ddc"></td>
         <td id="swSWISS"></td>

--- a/isbn/suche.html
+++ b/isbn/suche.html
@@ -305,7 +305,7 @@ function isbnEingabe(n) {
     $('#suche'+'HEBIS').html('<a href="http://cbsopac.rz.uni-frankfurt.de/DB=2.1/SET=1/TTL=1/CMD?ACT=SRCHA&IKT=8520&TRM='+nArray[0]+'" target="_blank">HEBIS</a>');
     $('#suche'+'B3KAT').html('<a href="https://opacplus.bib-bvb.de/TouchPoint_touchpoint/start.do?Query=-1%3D%22' + nArray[0] + '%22&Language=De&SearchProfile=" target="_blank">B3KAT</a>');
     $('#suche'+'HBZ').html('<a href="http://okeanos-www.hbz-nrw.de/F/?FUNC=find-c&CCL_TERM=+IBN=%28'+nArray[0]+'" target="_blank">HBZ</a>');
-    $('#suche'+'SWISS').html('<a href="https://www.swissbib.ch/Search/Results?lookfor='+nArray[0]+'&type=AllFields&limit=20&sort=relevance" target="_blank">SWISS</a>');
+    $('#suche'+'SWISS').html('<a href="https://swisscovery.slsp.ch/discovery/search?query=isbn,contains,'+nArray[0]+',AND&tab=41SLSP_NETWORK&search_scope=DN_and_CI&vid=41SLSP_NETWORK:VU1_UNION&mode=advanced&offset=0" target="_blank">SWISS</a>');
     $('#suche'+'OBVSG').html('<a href="http://search.obvsg.at/primo_library/libweb/action/search.do?fn=search&ct=search&initialSearch=true&mode=Basic&tab=default_tab&indx=1&dum=true&srt=rank&vid=OBV&tb=t&vl%28freeText0%29='+nArray[0]+'" target="_blank">OBVSG</a>');
 
     

--- a/isbn/swiss.php
+++ b/isbn/swiss.php
@@ -40,7 +40,6 @@ https://slsp.ch/de/metadata
 */
 
 $urlBase = 'https://swisscovery.slsp.ch/view/sru/41SLSP_NETWORK?version=1.2&operation=searchRetrieve&recordSchema=marcxml&query=';
-
 if (isset($_GET['isbn'])) {
     $n = trim($_GET['isbn']);
     $nArray = preg_split("/\s*(or|,|;)\s*/i", $n);
@@ -53,6 +52,10 @@ $contextOptions = [
     'ssl' => [
         'verify_peer' => true,
         'ciphers' => 'DEFAULT@SECLEVEL=1',
+    ],
+    'http' => [
+	    'header' => 'Connection: close\r\n',
+	    'timeout' => 3,
     ],
 ];
 $context = stream_context_create($contextOptions);

--- a/isbn/swiss.php
+++ b/isbn/swiss.php
@@ -2,7 +2,7 @@
 /*
  * Source: https://github.com/UB-Mannheim/malibu/isbn
  *
- * Copyright (C) 2015 Universitätsbibliothek Mannheim
+ * Copyright (C) 2021 Universitätsbibliothek Mannheim
  *
  * Author:
  *    Philipp Zumstein <philipp.zumstein@bib.uni-mannheim.de>
@@ -12,18 +12,13 @@
  * See <http://www.gnu.org/licenses/> for more details.
  *
  * Aufruf aus Webbrowser:
- * swissbib?isbn=ISBN
+ * swiss.php?isbn=ISBN
  *   ISBN ist eine 10- bzw. 13-stellige ISBN mit/ohne Bindestriche/Leerzeichen
  *   ISBN kann ebenfalls eine Komma-separierte Liste von ISBNs sein
- * swissbib?ppn=PPN
- *   PPN ist die eine ID-Nummer des swissbib
- * swissbib?isbn=ISBN&format=json
- * swissbib?ppn=PPN&format=json
- *   Ausgabe erfolgt als JSON
+ * swiss.php?isbn=ISBN&format=json
  *
- * Sucht übergebene ISBN bzw. PPN im swissbib-Katalog
- * und gibt maximal 10 Ergebnisse als MARCXML zurück
- * bzw. als JSON.
+ * Sucht übergebene ISBN bzw. PPN in der SRU-Schnittstelle von Swisscovery (SLSP)
+ * und gibt maximal 10 Ergebnisse als MARCXML oder JSON zurück.
  */
 
 include 'lib.php';
@@ -34,36 +29,46 @@ if (isset($_GET['ppn'])) {
 }
 
 /*
-https://sru.swissbib.ch/sru/search/defaultdb?query=
-+dc.identifier+%3D+978981-4447508+OR+dc.identifier+%3D+981444751
-&operation=searchRetrieve&recordSchema=info%3Asrw%2Fschema%2F1%2Fmarcxml-v1.1-light&maximumRecords=10&x-info-10-get-holdings=true&startRecord=0&recordPacking=XML&availableDBs=defaultdb&sortKeys=Submit+query
+Explain SRU
+
+https://swisscovery.slsp.ch/view/sru/41SLSP_NETWORK?version=1.2&operation=explain
+
+Nutzung SLSP-Metadaten
+
+https://slsp.ch/de/metadata
+
 */
 
-$urlBase = 'https://sru.swissbib.ch/sru/search/defaultdb?query=';
-$urlSuffix = '&operation=searchRetrieve&recordSchema=info%3Asrw%2Fschema%2F1%2Fmarcxml-v1.1-light&maximumRecords=10&x-info-10-get-holdings=true&startRecord=0&recordPacking=XML&availableDBs=defaultdb&sortKeys=Submit+query';
+$urlBase = 'https://swisscovery.slsp.ch/view/sru/41SLSP_NETWORK?version=1.2&operation=searchRetrieve&recordSchema=marcxml&query=';
 
 if (isset($_GET['isbn'])) {
     $n = trim($_GET['isbn']);
-    $nArray = explode(",", $n);
-    $suchString = 'dc.identifier=' . implode('+OR+dc.identifier=', $nArray);
+    $nArray = preg_split("/\s*(or|,|;)\s*/i", $n);
+    $suchString = 'alma.all=' . implode('+OR+alma.all=', $nArray);
+    $suchStringSWB = implode(' or ', $nArray);
 }
-
-# work around server configuration issue
+$filteredSuchString = 'alma.mms_tagSuppressed=false+AND+(' . $suchString . ')';
+# work around ExLibris server configuration issue
 $contextOptions = [
     'ssl' => [
-        'verify_peer' => false,
+        'verify_peer' => true,
+        'ciphers' => 'DEFAULT@SECLEVEL=1',
     ],
 ];
 $context = stream_context_create($contextOptions);
-$result = file_get_contents($urlBase . $suchString . $urlSuffix, false, $context);
+$result = file_get_contents($urlBase . $filteredSuchString, false, $context);
 
 if ($result === false) {
     header('HTTP/1.1 400 Bad Request');
-    var_dump($urlBase . $suchString . $urlSuffix);
+    echo "Verbindung zu SRU-Schnittstelle fehlgeschlagen\n";
+    var_dump($urlBase . $filteredSuchString);
     exit;
 }
 
+// Delete namespaces such that we don't need to specify them
+// in every xpath query.
 $result = str_replace(' xmlns:xs="http://www.w3.org/2001/XMLSchema"', '', $result);
+$result = str_replace(' xmlns="http://www.loc.gov/MARC21/slim"', '', $result);
 
 $doc = new DOMDocument();
 $doc->preserveWhiteSpace = false;
@@ -76,17 +81,36 @@ $outputString = "<?xml version=\"1.0\"?>\n";
 $outputString .= "<collection>\n";
 $outputArray = [];
 
-foreach ($records as $record) {
 
-    $outputString .= $doc->saveXML($record);
-    array_push($outputArray, $doc->saveXML($record));
+foreach ($records as $record) {
+    // Filter out any other results which contain the ISBN but not in the 020 or 776 field
+    $foundMatch = false;
+    $foundIsbns = $xpath->query('.//datafield[@tag="020" or @tag="776"]/subfield', $record);
+    foreach ($foundIsbns as $foundNode) {
+        $foundValue = $foundNode->nodeValue;
+        foreach ($nArray as $queryValue) {
+            $testString = preg_replace('/[^0-9xX]/', '', $queryValue);
+            if (strlen($testString) == 13) {
+                // Delete the 978-prefix and the check value at the end for ISBN13
+                $testString = substr($testString, 3, -1);
+            } elseif (strlen($testString) == 10) {
+                // Delete check value at the end for ISBN10
+                $testString = substr($testString, 0, -1);
+            }
+            if (strpos(preg_replace('[^0-9xX]', '', $foundValue), $testString) !== false) {
+                $foundMatch = true;
+            }
+        }
+    }
+    if ($foundMatch) {
+        $outputString .= $doc->saveXML($record);
+        array_push($outputArray, $doc->saveXML($record));
+    }
 }
 $outputString .= "</collection>";
 
-
 $map = $standardMarcMap;
-$map['bestand'] = '//datafield[@tag="949" or @tag="852"]/subfield[@code="F"]';
-$map['sw']['additional'] = './subfield[@code="z"]';
+$map['bestand'] = '//datafield[@tag="AVA"]/subfield[@code="b"]';
 
 if (!isset($_GET['format'])) {
     header('Content-type: text/xml');
@@ -107,3 +131,4 @@ if (!isset($_GET['format'])) {
     header('Content-type: application/json');
     echo json_encode($outputMap, JSON_PRETTY_PRINT);
 }
+


### PR DESCRIPTION
Swisscovery als neuer Katalog der Schweiz von SLSP bietet für die
Metadaten eine SRU-Schnittstelle von deren Alma-Instanz an. Daher
konnte man den Code von man-sru.php adaptieren.

Fixes #132.