### PR TITLE
:bug: Bestandsabfrage man-sru.php korrigiert

### DIFF
--- a/isbn/man-sru.php
+++ b/isbn/man-sru.php
@@ -94,7 +94,7 @@ foreach ($records as $record) {
                 // Delete check value at the end for ISBN10
                 $testString = substr($testString, 0, -1);
             }
-            if (strpos(preg_replace('[^0-9xX]', '', $foundValue), $testString) !== false) {
+            if (strpos(preg_replace('/[^0-9xX]/', '', $foundValue), $testString) !== false) {
                 $foundMatch = true;
             }
         }


### PR DESCRIPTION
Beim PR #125 wurde dieser Bug eingebut. In der Folge war jetzt
teilweise der Betandsabgleich für man-sru.php nicht korrekt.
Insbesondere Titel, welche nur in Alma katalogisiert wurden,
ohne generisches ISBN-Format könnten davon betroffen gewesen
sein. Konkretes Beispiel ist die ISBN 90-420-2861-0.