### PR TITLE
obvsg: Vermeide Warnung bzgl. fehlendem Array-Eintrag (Feld additional)

### DIFF
--- a/isbn/obvsg.php
+++ b/isbn/obvsg.php
@@ -111,11 +111,7 @@ foreach ($records as $record) {
 $outputString .= "</collection>";
 
 $map = $standardMarcMap;
-$map['sw'] = array(
-        'mainPart' => '//datafield[starts-with(@tag,"689")]',
-        'value' => './subfield[@code="a"]',
-        'key' => './subfield[@code="0" and contains(text(), "(DE-588)")]'
-    );
+$map['sw']['mainPart'] = '//datafield[starts-with(@tag,"689")]';
 
 if (!isset($_GET['format'])) {
     header('Content-type: text/xml');


### PR DESCRIPTION
Vermeidet PHP-Warnung bzgl. Undefined Index: Dem überschriebenen Stichwort-/sw-Array in der MarcMap fehlte das Feld 'additional'.
Statt das Array zu ersetzen genügt es nur den einen abweichenden Eintrag zu überschreiben.