### PR TITLE
Vermeide Warnung bzgl. nicht definiertem Zeiger (empty needle)

### DIFF
--- a/isbn/man-sru.php
+++ b/isbn/man-sru.php
@@ -41,7 +41,7 @@ $urlBase = 'https://uni-mannheim.alma.exlibrisgroup.com/view/sru/49MAN_INST?vers
 
 if (isset($_GET['isbn'])) {
     $n = trim($_GET['isbn']);
-    $nArray = preg_split("/\s*(or|,|;)\s*/i", $n);
+    $nArray = preg_split("/\s*(or|,|;)\s*/i", $n, -1, PREG_SPLIT_NO_EMPTY);
     $suchString = 'alma.all=' . implode('+OR+alma.all=', $nArray);
     $suchStringSWB = implode(' or ', $nArray);
 }

--- a/isbn/obvsg.php
+++ b/isbn/obvsg.php
@@ -42,7 +42,7 @@ if (!$searchPPN && isset($_GET['isbn'])) {
     $searchISBN = true;
 }
 if ($searchPPN || $searchISBN) {
-    $nArray = preg_split("/\s*(or|,|;)\s*/i", $n);
+    $nArray = preg_split("/\s*(or|,|;)\s*/i", $n, -1, PREG_SPLIT_NO_EMPTY);
     $suchString = 'alma.all=' . implode('+OR+alma.all=', $nArray);
 }
 

--- a/isbn/swiss.php
+++ b/isbn/swiss.php
@@ -42,7 +42,7 @@ https://slsp.ch/de/metadata
 $urlBase = 'https://swisscovery.slsp.ch/view/sru/41SLSP_NETWORK?version=1.2&operation=searchRetrieve&recordSchema=marcxml&query=';
 if (isset($_GET['isbn'])) {
     $n = trim($_GET['isbn']);
-    $nArray = preg_split("/\s*(or|,|;)\s*/i", $n);
+    $nArray = preg_split("/\s*(or|,|;)\s*/i", $n, -1, PREG_SPLIT_NO_EMPTY);
     $suchString = 'alma.all=' . implode('+OR+alma.all=', $nArray);
     $suchStringSWB = implode(' or ', $nArray);
 }


### PR DESCRIPTION
Wenn bei der isbn-Suche der Suchstring mit einem Trennzeichen wie ',' oder ';' endet, erzeugen die Suchen via man-sru, swiss und obvsg zahlreiche Warnungen der Form
`PHP Warning:  strpos(): Empty needle in /var/www/html/malibu/isbn/obvsg.php on line 100, referer: ...```

Dies lässt sich vermeiden indem bei der Trennung des Suchstrings leere Einträge verworfen werden (via PREG_SPLIT_NO_EMPTY).

TODO:
Die anderen Suchen (K10Plus, B3Kat, HBZ) liefern für eine einzelne, gültige isbn mit angehängtem Trennzeichen kein Ergebnis.