### PR TITLE
Add GitHub action for CI (replacement for Travis CI)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,28 @@
+# GitHub action for continuous integration of UB-Mannheim/malibu
+
+name: Check code
+
+on:
+  pull_request:
+
+  push:
+
+jobs:
+  ci:
+    name: CI checks
+    runs-on: ubuntu-latest
+
+    steps:
+      # Checkout the repository to the GitHub Actions runner
+      - name: Checkout code
+        uses: actions/checkout@v3
+
+      - name: Install dependencies
+        # php-codesniffer is used for the PSR-2 conformance test.
+        # shellcheck for testing shell scripts for common pitfalls
+        run: |
+             sudo apt-get --quiet update
+             sudo apt-get install --yes php-codesniffer shellcheck
+
+      - name: Run php-codeniffer and shellcheck
+        run: dist/pre-commit.sh .

--- a/README.md
+++ b/README.md
@@ -1,5 +1,6 @@
 # malibu - Mannheim library utilities
 
+[![Check code](https://github.com/UB-Mannheim/malibu/actions/workflows/ci.yml/badge.svg)](https://github.com/UB-Mannheim/malibu/actions/workflows/ci.yml)
 [![Build Status](https://travis-ci.org/UB-Mannheim/malibu.svg?branch=master)](https://travis-ci.org/UB-Mannheim/malibu)
 [![GitHub release](https://img.shields.io/github/release/UB-Mannheim/malibu.svg?maxAge=3600)](https://github.com/UB-Mannheim/malibu/releases)
 [![license](https://img.shields.io/github/license/UB-Mannheim/malibu.svg?maxAge=2592000)](https://github.com/UB-Mannheim/malibu/blob/master/LICENSE)


### PR DESCRIPTION
Travis can be removed in a follow-up commit. Currently the CI fails because the code in master is not "clean".