### PR TITLE
Add requirements.txt

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,0 +1,2 @@
+bs4
+requests


### PR DESCRIPTION
This file is not needed for Linux distributions which provide Python and the required Python packages, but it is useful to document the Python dependencies and allows installation on non Linux hosts.