### PR TITLE
INSTALL.md: rewrite section concerning Debian

### DIFF
--- a/INSTALL.md
+++ b/INSTALL.md
@@ -8,11 +8,7 @@ it up on Debian without docker and how you can set up a
 an environment for code development.
 
 * [Server configuration](#server-configuration)
-  * [For Debian 7 (Apache 2.2)](#for-debian-7-apache-22)
-  * [For Debian 8 (Apache 2.4)](#for-debian-8-apache-24)
-  * [For Debian 9 (Apache 2.4 and PHP 7.0)](#for-debian-9-apache-24-and-php-70)
-  * [For Debian 10 (Apache 2.4 and PHP 7.3)](#for-debian-10-apache-24-and-php-73)
-  * [For Debian 11 (Apache 2.4 and PHP 7.4)](#for-debian-11-apache-24-and-php-74)
+  * [For Debian 9+ (Apache)](#for-debian-9-apache)
   * [For UBUNTU 18.04 LTS / 20.04 LTS (Apache 2.4 and PHP 7.4)](#for-ubuntu-1804-lts-apache-24-and-php-74)
 * [Initializing and Costumizing](#initializing-and-costumizing)
 * [Configuration for code development](#configurations-for-code-development)
@@ -22,99 +18,13 @@ an environment for code development.
 
 ## Server configuration
 
-### For Debian 7 (Apache 2.2)
-You need the php library <a href="http://php.net/manual/en/book.yaz.php">yaz</a> on the server.
-
-1. <code>apt-get install yaz libyaz4-dev php5-dev php-pear</code> (maybe you have already some packages)
-2. <code>pecl install yaz</code>
-3. Open `/etc/php5/apache2/php.ini`, goto section `Dynamic Extensions` and add `extension=yaz.so`
-
-Maybe, the file `yaz.so` is not located in the directory
-which is configured by `extension_dir` in
-`/etc/alternatives/php-config` and you have to copy it therefore.
-(e.g. <code>cp /usr/lib/php5/20090626/yaz.so /usr/lib/php5/20100525/yaz.so</code> in our case).
-
-### For Debian 8 (Apache 2.4)
-You need the php library <a href="http://php.net/manual/en/book.yaz.php">yaz</a> on the server.
-
-* <code>apt-get install yaz libyaz4-dev php5-dev php-pear</code> (maybe you have already some packages)
-* <code>pecl install yaz</code>
-* create new file `/etc/php5/mods-available/yaz.ini` and add
-```sh
-; configuration for php YAZ module
-; priority=20
-extension=yaz.so
-```
-* create a symbolic link
-```sh
-cd /etc/php5/apache2/conf.d
-ln -s ../../mods-available/yaz.ini 20-yaz.ini
-```
-* restart Apache2
-```sh
-service apache2 restart
-```
-
-### For Debian 9 (Apache 2.4 and PHP 7.0)
-You need the php library <a href="http://php.net/manual/en/book.yaz.php">yaz</a> on the server.
-
-* <code>apt-get install yaz libyaz4-dev php-dev php-pear libapache2-mod-php</code> (maybe you already have some packages)
-* <code>pecl install yaz</code>
-* create new file `/etc/php/7.0/mods-available/yaz.ini` and add
-```sh
-; configuration for php YAZ module
-; priority=20
-extension=yaz.so
-```
-* enable the YAZ module
-```sh
-phpenmod yaz
-```
-* restart Apache2 server
-```sh
-systemctl restart apache2
-```
-
-### For Debian 10 (Apache 2.4 and PHP 7.3)
+### For Debian 9+ (Apache)
 You need the php library <a href="http://php.net/manual/en/book.yaz.php">yaz</a> on the server.
 
 * <code>apt-get install yaz libyaz-dev php-dev php-pear libapache2-mod-php</code> (maybe you already have some packages)
 * <code>pecl install yaz</code>
-* create new file `/etc/php/7.3/mods-available/yaz.ini` and add
-```sh
-; configuration for php YAZ module
-; priority=20
-extension=yaz.so
-```
-* enable the YAZ module
-```sh
-phpenmod yaz
-```
-* restart Apache2 server
-```sh
-systemctl restart apache2
-```
-
-### For Debian 11 (Apache 2.4 and PHP 7.4)
-Basically the same as for Debian 10 BUT **yaz-config** is not available anymore, so the installation step <code>pecl install yaz</code> will fail.
-
-You need the php library <a href="http://php.net/manual/en/book.yaz.php">yaz</a> on the server.
-
-* <code>apt-get install yaz php-dev php-pear libapache2-mod-php7.4</code> (maybe you already have some packages)
-
-
-* <code>wget -O yaz.tar.gz http://pecl.php.net/get/yaz</code>
-* <code>tar -zxvf yaz.tar.gz</code>
-* <code>cd yaz-<version></code>
-* replace file `config.m4` with `extra/config.m4` from this repository
-* <code>phpize</code>
-* <code>./configure</code>
-* <code>make</code>
-* <code>make test</code>
-* <code>make install</code>
-
-
-* create new file `/etc/php/7.4/mods-available/yaz.ini` and add
+* <code>PHPVERSION=$(dpkg -s libapache2-mod-php | grep -e '^Depends:' | grep -o '[0-9.]\\+$')</code>
+* create new file `/etc/php/${PHPVERSION}/mods-available/yaz.ini` and add
 ```sh
 ; configuration for php YAZ module
 ; priority=20
@@ -163,7 +73,7 @@ sudo phpenmod yaz
 sudo systemctl restart apache2
 ```
 
-## Initializing and Costumizing
+## Initializing and Customizing
 
 Some steps have to be performed after the server configuration and
 before the first start:
@@ -179,6 +89,10 @@ Moreover, for the retrieval of data from the British National Library, you shoul
 0 10 * * 6 /var/www/html/malibu/bnb/getBNBData /var/www/html/malibu/bnb/BNBDaten
 ```
 
+This script requires the python module BeautifulSoup 4. Install it e.g. on Debian with:
+```sh
+sudo apt-get install python3-bs4
+```
 
 ## Configurations for code development
 


### PR DESCRIPTION
Checked installation documentation for new Debian release 12 (Bookworm) and streamlined it by removing ancient versions and generalizing the instructions.