### PR TITLE
Fix phpcs errors

### DIFF
--- a/bnb/bnb.php
+++ b/bnb/bnb.php
@@ -25,7 +25,6 @@
 header('Content-type: text/xml');
 
 if (isset($_GET['nr'])) {
-
     if (is_string($_GET['nr'])) {
         $nrArray = explode(',', $_GET['nr']);
     } else {

--- a/bnb/recherche.php
+++ b/bnb/recherche.php
@@ -1,7 +1,7 @@
 <!DOCTYPE html>
 <html>
 <!--
-Source: https://github.com/UB-Mannheim/malibu/bnb
+Source: https://github.com/UB-Mannheim/malibu/
 
 Copyright (C) 2013 Universitätsbibliothek Mannheim
 

--- a/dist/php-codesniffer.sh
+++ b/dist/php-codesniffer.sh
@@ -39,4 +39,4 @@ if [[ -z "$CODE_SNIFFER" ]];then
     CODE_SNIFFER="php $CS_PHAR"
 fi
 
-$CODE_SNIFFER --standard="$PHP_CODE_STANDARD" -s "$@"
+$CODE_SNIFFER --standard="$PHP_CODE_STANDARD" --ignore=*.min.js -s "$@"

--- a/isbn/b3kat.php
+++ b/isbn/b3kat.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Source: https://github.com/UB-Mannheim/malibu/isbn
+ * Source: https://github.com/UB-Mannheim/malibu/
  *
  * Copyright (C) 2013 Universitätsbibliothek Mannheim
  *
@@ -26,6 +26,7 @@
  * bzw. als JSON.
  */
 
+include 'conf.php';
 include 'lib.php';
 
 $id = yaz_connect(B3KAT_URL, array("user" => B3KAT_USER, "password" => B3KAT_PASSWORD)); //"mab2; charset=iso5426,utf8"
@@ -80,21 +81,18 @@ for ($p = 1; $p <= yaz_hits($id); $p++) {
     $recordContent .= '</datensatz>' . "\n";
     $outputString .= $recordContent;
     array_push($outputArray, $recordContent);
-
 }
 
 $outputString .= "</datei>";
 yaz_close($id);
 
-$map = $standardMabMap;
+$map = STANDARD_MAB_MAP;
 $map['bestand'] = '//feld[@nr="LOW" and @ind="a"]';
 
 if (!isset($_GET['format'])) {
     header('Content-type: text/xml');
     echo $outputString;
-
-} else if ($_GET['format'] == 'json') {
-
+} elseif ($_GET['format'] == 'json') {
     $outputXml = simplexml_load_string($outputString);
     $outputMap = performMapping($map, $outputXml);
     $outputIndividualMap = [];

--- a/isbn/bl.php
+++ b/isbn/bl.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Source: https://github.com/UB-Mannheim/malibu/isbn
+ * Source: https://github.com/UB-Mannheim/malibu/
  *
  * Copyright (C) 2013 Universitätsbibliothek Mannheim
  *
@@ -22,6 +22,7 @@
  * bzw. als JSON.
  */
 
+include 'conf.php';
 include 'lib.php';
 
 $id = yaz_connect(BL_URL, array("user" => BL_USER, "password" => BL_PASSWORD));
@@ -69,16 +70,14 @@ $outputString .= "</collection>";
 
 yaz_close($id);
 
-$map = $standardMarcMap;
+$map = STANDARD_MARC_MAP;
 $map['bestand'] = '//datafield[@tag="900"]/subfield[@code="b"]';
 
 
 if (!isset($_GET['format'])) {
     header('Content-type: text/xml');
     echo $outputString;
-
-} else if ($_GET['format'] == 'json') {
-
+} elseif ($_GET['format'] == 'json') {
     $outputXml = simplexml_load_string($outputString);
     $outputMap = performMapping($map, $outputXml);
     $outputIndividualMap = [];

--- a/isbn/gbv.php
+++ b/isbn/gbv.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Source: https://github.com/UB-Mannheim/malibu/isbn
+ * Source: https://github.com/UB-Mannheim/malibu/
  *
  * Copyright (C) 2013 Universitätsbibliothek Mannheim
  *
@@ -26,6 +26,7 @@
  * bzw. als JSON.
  */
 
+include 'conf.php';
 include 'lib.php';
 
 $id = yaz_connect(GBV_URL);
@@ -43,7 +44,8 @@ if (isset($_GET['isbn'])) {
     if (count($nArray) > 1) {
         //mehrere ISBNs, z.B. f @or @or @attr 1=7 "9783937219363" @attr 1=7 "9780521369107" @attr 1=7 "9780521518147"
         //Anfuehrungsstriche muessen demaskiert werden, egal ob String mit ' gemacht wird
-        $suchString = str_repeat("@or ", count($nArray) - 1) . '@attr 1=7 \"' . implode('\" @attr 1=7 \"', $nArray) . '\"';
+        $suchString = str_repeat("@or ", count($nArray) - 1) . '@attr 1=7 \"'
+                    . implode('\" @attr 1=7 \"', $nArray) . '\"';
         yaz_search($id, "rpn", $suchString);
     } else {
         yaz_search($id, "rpn", '@attr 5=100 @attr 1=7 "' . $n . '"');
@@ -75,16 +77,14 @@ $outputString .= "</collection>";
 
 yaz_close($id);
 
-$map = $standardMarcMap;
+$map = STANDARD_MARC_MAP;
 $map['bestand'] = '//datafield[@tag="900"]/subfield[@code="b"]';
 
 
 if (!isset($_GET['format'])) {
     header('Content-type: text/xml');
     echo $outputString;
-
-} else if ($_GET['format'] == 'json') {
-
+} elseif ($_GET['format'] == 'json') {
     $outputXml = simplexml_load_string($outputString);
     $outputMap = performMapping($map, $outputXml);
     $outputIndividualMap = [];

--- a/isbn/hbz.php
+++ b/isbn/hbz.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Source: https://github.com/UB-Mannheim/malibu/isbn
+ * Source: https://github.com/UB-Mannheim/malibu/
  *
  * Copyright (C) 2013 Universitätsbibliothek Mannheim
  *
@@ -26,6 +26,7 @@
  * bzw. als JSON.
  */
 
+include 'conf.php';
 include 'lib.php';
 
 $id = yaz_connect(HBZ_URL);
@@ -44,7 +45,8 @@ if (isset($_GET['isbn'])) {
     if (count($nArray) > 1) {
         //mehrere ISBNs, z.B. f @or @or @attr 1=7 "9783937219363" @attr 1=7 "9780521369107" @attr 1=7 "9780521518147"
         //Anfuehrungsstriche muessen demaskiert werden, egal ob String mit ' gemacht wird
-        $suchString = str_repeat("@or ", count($nArray) - 1) . '@attr 1=7 \"' . implode('\" @attr 1=7 \"', $nArray) . '\"';
+        $suchString = str_repeat("@or ", count($nArray) - 1) . '@attr 1=7 \"'
+                    . implode('\" @attr 1=7 \"', $nArray) . '\"';
         yaz_search($id, "rpn", $suchString);
     } else {
         yaz_search($id, "rpn", '@attr 5=100 @attr 1=7 "' . $n . '"');
@@ -74,7 +76,9 @@ for ($p = 1; $p <= yaz_hits($id); $p++) {
     }
     $recordArray = explode("\x1e", $record);
     $header = substr($recordArray[0], 0, 24);
-    $recordContent = '<datensatz id="" typ="' . substr($header, 23, 1) . '" status="' . substr($header, 5, 1) . '" mabVersion="' . substr($header, 6, 4) . '">' . "\n";
+    $recordContent = '<datensatz id="" typ="' . substr($header, 23, 1) . '" status="'
+                   . substr($header, 5, 1) . '" mabVersion="'
+                   . substr($header, 6, 4) . '">' . "\n";
     $recordContent .= printLine(substr($recordArray[0], 24));
 
 
@@ -90,14 +94,12 @@ for ($p = 1; $p <= yaz_hits($id); $p++) {
 $outputString .= "</datei>";
 yaz_close($id);
 
-$map = $standardMabMap;
+$map = STANDARD_MAB_MAP;
 
 if (!isset($_GET['format'])) {
     header('Content-type: text/xml');
     echo $outputString;
-
-} else if ($_GET['format'] == 'json') {
-
+} elseif ($_GET['format'] == 'json') {
     $outputXml = simplexml_load_string($outputString);
     $outputMap = performMapping($map, $outputXml);
     $outputIndividualMap = [];

--- a/isbn/hebis.php
+++ b/isbn/hebis.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Source: https://github.com/UB-Mannheim/malibu/isbn
+ * Source: https://github.com/UB-Mannheim/malibu/
  *
  * Copyright (C) 2013 Universitätsbibliothek Mannheim
  *
@@ -26,6 +26,7 @@
  * bzw. als JSON.
  */
 
+include 'conf.php';
 include 'lib.php';
 
 $id = yaz_connect(HEBIS_URL);
@@ -76,14 +77,14 @@ for ($p = 1; $p <= yaz_hits($id); $p++) {
 $outputString .= "</collection>";
 yaz_close($id);
 
-$map = $standardMarcMap;
+$map = STANDARD_MARC_MAP;
 $map['bestand'] = '//datafield[@tag="924"]/subfield[@code="b"]';
 
 
 if (!isset($_GET['format'])) {
     header('Content-type: text/xml');
     echo $outputString;
-} else if ($_GET['format'] == 'json') {
+} elseif ($_GET['format'] == 'json') {
     $outputXml = simplexml_load_string($outputString);
     $outputMap = performMapping($map, $outputXml);
     $outputIndividualMap = [];

--- a/isbn/k10plus.php
+++ b/isbn/k10plus.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Source: https://github.com/UB-Mannheim/malibu/isbn
+ * Source: https://github.com/UB-Mannheim/malibu/
  *
  * Copyright (C) 2019 Universitätsbibliothek Mannheim
  *
@@ -30,6 +30,7 @@
  * Info zur SRU-Schnittstelle: https://wiki.k10plus.de/display/K10PLUS/SRU
  */
 
+include 'conf.php';
 include 'lib.php';
 
 $urlBase = 'https://sru.k10plus.de/opac-de-627?version=1.1&operation=searchRetrieve&query=';
@@ -74,14 +75,13 @@ $outputString .= "<collection>\n";
 $outputArray = [];
 
 foreach ($records as $record) {
-
     $outputString .= $doc->saveXML($record);
     array_push($outputArray, $doc->saveXML($record));
 }
 $outputString .= "</collection>";
 
 
-$map = $standardMarcMap;
+$map = STANDARD_MARC_MAP;
 $map['bestand'] = '//datafield[@tag="924"]/subfield[@code="b"]';
 //TODO special mapping K10PLUS, if needed?
 //$map['bestand'] = '//datafield[@tag="949" or @tag="852"]/subfield[@code="F"]';
@@ -90,7 +90,7 @@ $map['bestand'] = '//datafield[@tag="924"]/subfield[@code="b"]';
 if (!isset($_GET['format'])) {
     header('Content-type: text/xml');
     echo $outputString;
-} else if ($_GET['format'] == 'json') {
+} elseif ($_GET['format'] == 'json') {
     $outputXml = simplexml_load_string($outputString);
 
     $outputMap = performMapping($map, $outputXml);

--- a/isbn/malibu_light.css
+++ b/isbn/malibu_light.css
@@ -139,7 +139,7 @@ hr {
 }
 
 #ChangeDesignButton:hover {
-  cursor: pointer; 
+  cursor: pointer;
 }
 
 

--- a/isbn/man-sru.php
+++ b/isbn/man-sru.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Source: https://github.com/UB-Mannheim/malibu/isbn
+ * Source: https://github.com/UB-Mannheim/malibu/
  *
  * Copyright (C) 2016 Universitätsbibliothek Mannheim
  *
@@ -24,6 +24,7 @@
  * Tabelle).
  */
 
+include 'conf.php';
 include 'lib.php';
 
 $suchString = '';
@@ -115,13 +116,13 @@ foreach ($records as $record) {
 $outputString .= "</collection>";
 
 
-$map = $standardMarcMap;
+$map = STANDARD_MARC_MAP;
 $map['bestand'] = '//datafield[@tag="AVA"]/subfield[@code="b"]';
 
 if (!isset($_GET['format'])) {
     header('Content-type: text/xml');
     echo $outputString;
-} else if ($_GET['format'] == 'json') {
+} elseif ($_GET['format'] == 'json') {
     $outputXml = simplexml_load_string($outputString);
 
     $outputMap = performMapping($map, $outputXml);
@@ -136,7 +137,7 @@ if (!isset($_GET['format'])) {
 
     header('Content-type: application/json');
     echo json_encode($outputMap, JSON_PRETTY_PRINT);
-} else if ($_GET['format'] == 'holdings') {
+} elseif ($_GET['format'] == 'holdings') {
     echo "<html>\n<head>\n	<title>Bestand UB Mannheim zu ISBN-Suche</title>\n	<meta http-equiv='content-type' content='text/html; charset=UTF-8' />\n	<style type='text/css'>body { font-family:  Arial, Verdana, sans-serif; }</style>\n</head>\n<body>\n";
     $outputXml = simplexml_load_string($outputString);
     $avaNodes = $outputXml->xpath('//datafield[@tag="AVA"]');
@@ -196,7 +197,7 @@ if (!isset($_GET['format'])) {
             echo "E";
         }
         echo '</div>';
-    } else if ($aveNodes and !$avaNodes) {
+    } elseif ($aveNodes and !$avaNodes) {
         echo "<table>\n";
         foreach ($aveNodes as $node) {
             echo "<tr>\n";
@@ -211,7 +212,7 @@ if (!isset($_GET['format'])) {
         echo "</table>\n";
         echo "<hr/>\n";
         echo '<div>Bestand der UB Mannheim: E</div>';
-    } else if ($size > 100) {
+    } elseif ($size > 100) {
         //if the isbn is not found, then the $outputString is a minimal xml document
         //of size 48, for larger size something might be found...
         $urlMAN = 'man-sru.php?isbn=' . $suchStringSWB;
@@ -225,7 +226,7 @@ if (!isset($_GET['format'])) {
         $ncoins = substr_count($contentSWB, 'class="Z3988"');
         if ($nhits > 0) {//multiple results
             echo '<div>Bestand der UB Mannheim: SWB sagt ja (<a href="' . $urlSWB . '" target="_blank">' . $nhits / 2 . ' Treffer</a>)</div>';
-        } else if ($ncoins > 0) {//single result
+        } elseif ($ncoins > 0) {//single result
             echo '<div>Bestand der UB Mannheim: SWB sagt ja (<a href="' . $urlSWB . '" target="_blank">Einzeltreffer mit ' . $ncoins . ' COinS</a>)</div>';
         } else {
             echo 'Es wurde nichts gefunden';

--- a/isbn/nebis.php
+++ b/isbn/nebis.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Source: https://github.com/UB-Mannheim/malibu/isbn
+ * Source: https://github.com/UB-Mannheim/malibu/
  *
  * Copyright (C) 2014 Universitätsbibliothek Mannheim
  *
@@ -26,6 +26,7 @@
  * bzw. als JSON.
  */
 
+include 'conf.php';
 include 'lib.php';
 
 $id = yaz_connect(NEBIS_URL);
@@ -43,7 +44,8 @@ if (isset($_GET['isbn'])) {
     if (count($nArray) > 1) {
         //mehrere ISBNs, z.B. f @or @or @attr 1=7 "9783937219363" @attr 1=7 "9780521369107" @attr 1=7 "9780521518147"
         //Anfuehrungsstriche muessen demaskiert werden, egal ob String mit ' gemacht wird
-        $suchString = str_repeat("@or ", count($nArray) - 1) . '@attr 1=7 \"' . implode('\" @attr 1=7 \"', $nArray) . '\"';
+        $suchString = str_repeat("@or ", count($nArray) - 1) . '@attr 1=7 \"'
+                    . implode('\" @attr 1=7 \"', $nArray) . '\"';
         yaz_search($id, "rpn", $suchString);
     } else {
         yaz_search($id, "rpn", '@attr 5=100 @attr 1=7 "' . $n . '"');
@@ -75,16 +77,14 @@ $outputString .= "</collection>";
 
 yaz_close($id);
 
-$map = $standardMarcMap;
+$map = STANDARD_MARC_MAP;
 $map['bestand'] = '//datafield[@tag="900"]/subfield[@code="b"]';
 
 
 if (!isset($_GET['format'])) {
     header('Content-type: text/xml');
     echo $outputString;
-
-} else if ($_GET['format'] == 'json') {
-
+} elseif ($_GET['format'] == 'json') {
     $outputXml = simplexml_load_string($outputString);
     $outputMap = performMapping($map, $outputXml);
     $outputIndividualMap = [];

--- a/isbn/obvsg.php
+++ b/isbn/obvsg.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Source: https://github.com/UB-Mannheim/malibu/isbn
+ * Source: https://github.com/UB-Mannheim/malibu/
  *
  * Copyright (C) 2022 Universitätsbibliothek Mannheim
  *
@@ -21,6 +21,7 @@
  * und gibt maximal 10 Ergebnisse als MARCXML oder JSON zurück.
  */
 
+include 'conf.php';
 include 'lib.php';
 
 /*
@@ -110,7 +111,7 @@ foreach ($records as $record) {
 }
 $outputString .= "</collection>";
 
-$map = $standardMarcMap;
+$map = STANDARD_MARC_MAP;
 $map['sw'] = array(
         'mainPart' => '//datafield[starts-with(@tag,"689")]',
         'value' => './subfield[@code="a"]',
@@ -122,7 +123,7 @@ $map['sw'] = array(
 if (!isset($_GET['format'])) {
     header('Content-type: text/xml');
     echo $outputString;
-} else if ($_GET['format'] == 'json') {
+} elseif ($_GET['format'] == 'json') {
     $outputXml = simplexml_load_string($outputString);
 
     $outputMap = performMapping($map, $outputXml);

--- a/isbn/rendering.js
+++ b/isbn/rendering.js
@@ -5,18 +5,19 @@
  *
  * Author:
  *    Philipp Zumstein <philipp.zumstein@bib.uni-mannheim.de>
- * 
- * This is free software licensed under the terms of the GNU GPL, 
+ *
+ * This is free software licensed under the terms of the GNU GPL,
  * version 3, or (at your option) any later version.
  * See <http://www.gnu.org/licenses/> for more details.
- * 
+ *
  * Zusammenstellung von Javascript Funktionen hauptsächlich zur
  * Darstellung von den einzelnen Informationen.
  */
 
 
 //Standard Rendering
-function render(someArray, delimiter) {
+function render(someArray, delimiter)
+{
     //delimiter is optional and if not set single space will be used
     delimiter = typeof delimiter !== 'undefined' ? delimiter : ' ';
     if (typeof someArray === 'string') {
@@ -26,7 +27,8 @@ function render(someArray, delimiter) {
     }
 }
 
-function renderRVK(rvkArray) {
+function renderRVK(rvkArray)
+{
     if (typeof rvkArray === 'string') {
         return rvkArray;
     } else {
@@ -40,20 +42,21 @@ function renderRVK(rvkArray) {
         return rvkArray.sort().join(', ');
     }
 }
-function renderSigel(sigelArray){
-	var sigelMitZDBAlsLinks = "";
-	var trenner = ", ";
-	for (var i=0; i<sigelArray.length; i++) { 
-		if (sigelArray[i].startsWith("ZDB-")) { // render Sigel starting with ZDB- as links
-			sigelMitZDBAlsLinks += '<a href="https://sigel.staatsbibliothek-berlin.de/suche/?isil='+ sigelArray[i] + '" '  + 'target="_blank">' + sigelArray[i] + '</a>';
-		} else { // render other Sigel normally
-			sigelMitZDBAlsLinks += sigelArray[i];
-		}
-		if (i+1 < sigelArray.length) { //append separator if it is not the last item
-			sigelMitZDBAlsLinks += trenner; 
-		}
-	}
-	return sigelMitZDBAlsLinks;
+function renderSigel(sigelArray)
+{
+    var sigelMitZDBAlsLinks = "";
+    var trenner = ", ";
+    for (var i=0; i<sigelArray.length; i++) {
+        if (sigelArray[i].startsWith("ZDB-")) { // render Sigel starting with ZDB- as links
+            sigelMitZDBAlsLinks += '<a href="https://sigel.staatsbibliothek-berlin.de/suche/?isil='+ sigelArray[i] + '" '  + 'target="_blank">' + sigelArray[i] + '</a>';
+        } else { // render other Sigel normally
+            sigelMitZDBAlsLinks += sigelArray[i];
+        }
+        if (i+1 < sigelArray.length) { //append separator if it is not the last item
+            sigelMitZDBAlsLinks += trenner;
+        }
+    }
+    return sigelMitZDBAlsLinks;
 }
 
 //JSONP ist immer asynchron. Daher folgender Trick:
@@ -62,11 +65,12 @@ function renderSigel(sigelArray){
 //das Attribut title auf die entsprechende Benennung setzen.
 //Wichtig ist, dass die Link bereits da sein müssen, bevor
 //die Funktion hier aufgeruft wird.
-function addBenennung(index, element) {
+function addBenennung(index, element)
+{
     var className = $(element).attr('class');
     //z.B. https://rvk.uni-regensburg.de/api/json/ancestors/SU+680?jsonp=wrapper
     var rvkApi = 'https://rvk.uni-regensburg.de/api/json/ancestors/' + className.replace('-', '+') + '?jsonp=?';
-    $.getJSON(rvkApi, function(json) {
+    $.getJSON(rvkApi, function (json) {
         if ("node" in json) {
             if (json.node.ancestor) {//Benennung des Knoten + Benennung des Vorfahrens
                 $('.'+className).attr("title", json.node.benennung + ' <-- ' + json.node.ancestor.node.benennung);
@@ -81,7 +85,8 @@ function addBenennung(index, element) {
     });
 }
 
-function renderDDC(ddcArray) {
+function renderDDC(ddcArray)
+{
     if (typeof ddcArray === 'string') {
         return ddcArray;
     } else {
@@ -97,7 +102,8 @@ function renderDDC(ddcArray) {
 }
 
 
-function renderRelationen(relationenArray) {
+function renderRelationen(relationenArray)
+{
     if (typeof relationenArray === 'string') {
         return relationenArray;
     } else {
@@ -113,7 +119,9 @@ function renderRelationen(relationenArray) {
 var paketInfoMap = [];// kann um die lokalen Pakete ergänzt werden
 var overallPaketSigel = [];//alle bereits gefunden Sigel werden in einer Liste gespeichert
 
-function renderPS(psArray) {// PS = Produktsigel
+function renderPS(psArray)
+{
+// PS = Produktsigel
     if (typeof psArray === 'string') {
         return psArray;
     } else {
@@ -143,7 +151,8 @@ function renderPS(psArray) {// PS = Produktsigel
 //alle bereits gefundenen Links werden in ein Array gespeichert
 var overallLinks = [];
 
-function renderLinks(linkArray) {
+function renderLinks(linkArray)
+{
     if (typeof linkArray === 'string') {
         return linkArray;
     } else {
@@ -160,8 +169,9 @@ function renderLinks(linkArray) {
     }
 }
 
-function renderBestandSWB(bestandArray, id) {
-    var bibArray = $.map(bestandArray, function(sigel) {
+function renderBestandSWB(bestandArray, id)
+{
+    var bibArray = $.map(bestandArray, function (sigel) {
         if (sigel === "180") {
             return '<span style="border:2px solid red">180</span>';
         } else {
@@ -176,7 +186,8 @@ function renderBestandSWB(bestandArray, id) {
 //Einfache Ersetzung von einigen speziellen Zeichen
 //zur Darstellung als Text in HTML. Insbesondere bei
 //Homonymzusätzen.
-function htmlEscape(str) {
+function htmlEscape(str)
+{
     return String(str)
         .replace(/&/g, '&amp;')
         .replace(/"/g, '&quot;')
@@ -186,10 +197,11 @@ function htmlEscape(str) {
 }
 
 
-function renderSW(swObject) {
+function renderSW(swObject)
+{
     var swArray = [];
-    $.each(swObject, function(key, value) {
-        if(typeof value == 'string') {
+    $.each(swObject, function (key, value) {
+        if (typeof value == 'string') {
             var swUrl = 'https://d-nb.info/gnd/' + value + '/about/html';
             swArray.push('<a href="' + swUrl + '" target="_blank">' + htmlEscape(key) + '</a>');
         } else {
@@ -199,7 +211,8 @@ function renderSW(swObject) {
     return swArray.join('; ');
 }
 
-function bestellInfo(databaseText, currentRecord) {
+function bestellInfo(databaseText, currentRecord)
+{
     var content = databaseText+currentRecord.id+"\n";
     content += 'ISBN: ' + render(currentRecord.isbn, ', ') + "\n";
     content += render(currentRecord.titel) + ' ' + render(currentRecord.untertitel) + ' ' + render(currentRecord.autor);
@@ -213,23 +226,31 @@ function bestellInfo(databaseText, currentRecord) {
     return content;
 }
 
-function coins(currentRecord) {
+function coins(currentRecord)
+{
     // rudimentärer COinS Daten um beispielsweise Titel in Citavi, Zotero oder Mendeley zu speichern
     // und darüber Bestellungen zu verwalten:
     var coins = '<span class="Z3988" title="url_ver=Z39.88-2004&amp;ctx_ver=Z39.88-2004&amp;rft_val_fmt=info%3Aofi%2Ffmt%3Akev%3Amtx%3Abook';
-    if (currentRecord.titel) { coins += '&amp;rft.btitle=' + encodeURIComponent(currentRecord.titel); }
-    if (currentRecord.erscheinungsinfo) { coins += '&amp;rft.publisher=' + encodeURIComponent(currentRecord.erscheinungsinfo[1]); }
-    if (currentRecord.erscheinungsinfo) { coins += '&amp;rft.isbn=' + encodeURIComponent(currentRecord.isbn); }
-    if (currentRecord.auflage) { coins += '&amp;rft.edition=' + encodeURIComponent(currentRecord.auflage); }
-    if (currentRecord.autor) { coins += '&amp;rft.au=' + encodeURIComponent(currentRecord.autor); }
-    if (currentRecord.erscheinungsinfo) { coins += '&amp;rft.date=' + encodeURIComponent(currentRecord.erscheinungsinfo[2]); }
+    if (currentRecord.titel) {
+        coins += '&amp;rft.btitle=' + encodeURIComponent(currentRecord.titel); }
+    if (currentRecord.erscheinungsinfo) {
+        coins += '&amp;rft.publisher=' + encodeURIComponent(currentRecord.erscheinungsinfo[1]); }
+    if (currentRecord.erscheinungsinfo) {
+        coins += '&amp;rft.isbn=' + encodeURIComponent(currentRecord.isbn); }
+    if (currentRecord.auflage) {
+        coins += '&amp;rft.edition=' + encodeURIComponent(currentRecord.auflage); }
+    if (currentRecord.autor) {
+        coins += '&amp;rft.au=' + encodeURIComponent(currentRecord.autor); }
+    if (currentRecord.erscheinungsinfo) {
+        coins += '&amp;rft.date=' + encodeURIComponent(currentRecord.erscheinungsinfo[2]); }
     coins += '"></span>';
 
     return coins;
 }
  
 
-function getParameterByName(name) {
+function getParameterByName(name)
+{
 /*
  * Parameter als URL-Anhaenge werden direkt
  * ueber ihren Namen ansprechbar. Z.B.
@@ -242,7 +263,8 @@ function getParameterByName(name) {
 }
 
  
-function isbn10(z) {
+function isbn10(z)
+{
 /*
  * Umwandlung in eine 10-stellige ISBN,
  * wobei die Eingabe entweder bereits
@@ -260,7 +282,8 @@ function isbn10(z) {
     }
 }
 
-function isbn13(z) {
+function isbn13(z)
+{
 /*
  * Umwandlung in eine 13-stellige ISBN,
  * wobei die Eingabe entweder bereits

--- a/isbn/swb.php
+++ b/isbn/swb.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Source: https://github.com/UB-Mannheim/malibu/isbn
+ * Source: https://github.com/UB-Mannheim/malibu/
  *
  * Copyright (C) 2013 Universitätsbibliothek Mannheim
  *
@@ -26,6 +26,7 @@
  * bzw. als JSON.
  */
 
+include 'conf.php';
 include 'lib.php';
 
 $id = yaz_connect(SWB_URL);
@@ -72,13 +73,13 @@ for ($p = 1; $p <= yaz_hits($id); $p++) {
 $outputString .= "</collection>";
 yaz_close($id);
 
-$map = $standardMarcMap;
+$map = STANDARD_MARC_MAP;
 
 
 if (!isset($_GET['format'])) {
     header('Content-type: text/xml');
     echo $outputString;
-} else if ($_GET['format'] == 'json') {
+} elseif ($_GET['format'] == 'json') {
     $outputXml = simplexml_load_string($outputString);
 
     $outputMap = performMapping($map, $outputXml);

--- a/isbn/swiss.php
+++ b/isbn/swiss.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Source: https://github.com/UB-Mannheim/malibu/isbn
+ * Source: https://github.com/UB-Mannheim/malibu/
  *
  * Copyright (C) 2021 Universitätsbibliothek Mannheim
  *
@@ -21,6 +21,7 @@
  * und gibt maximal 10 Ergebnisse als MARCXML oder JSON zurück.
  */
 
+include 'conf.php';
 include 'lib.php';
 
 if (isset($_GET['ppn'])) {
@@ -112,13 +113,13 @@ foreach ($records as $record) {
 }
 $outputString .= "</collection>";
 
-$map = $standardMarcMap;
+$map = STANDARD_MARC_MAP;
 $map['bestand'] = '//datafield[@tag="AVA"]/subfield[@code="b"]';
 
 if (!isset($_GET['format'])) {
     header('Content-type: text/xml');
     echo $outputString;
-} else if ($_GET['format'] == 'json') {
+} elseif ($_GET['format'] == 'json') {
     $outputXml = simplexml_load_string($outputString);
 
     $outputMap = performMapping($map, $outputXml);


### PR DESCRIPTION
This PR touches a lot of files. Most changes were applied automatically using `phpcbf` .

Manual changes include:
- always point to https://github.com/UB-Mannheim/malibu/ when the source is attributed as linking to subdirectories does not work (anymore)
- explicitly include `conf.php` before `lib.php` in order to keep `lib.php` free from executed logic with side effects
- move function declarations from `verkaufsinfo.php`  to `lib.php`