### PR TITLE
Avoid warning (missing array key)

### DIFF
--- a/isbn/man-sru.php
+++ b/isbn/man-sru.php
@@ -202,7 +202,7 @@ if (!isset($_GET['format'])) {
         }
         if ($aveNodes) {
             echo "E";
-            if (isset($_GET['with']) && $_GET['with']) {
+            if (isset($_GET['with']) && $_GET['with']=="collections") {
                 sort($collections, SORT_STRING | SORT_FLAG_CASE);
                 echo ' (' . implode(" | ", $collections) . ')';
             }

--- a/isbn/man-sru.php
+++ b/isbn/man-sru.php
@@ -202,7 +202,7 @@ if (!isset($_GET['format'])) {
         }
         if ($aveNodes) {
             echo "E";
-            if ($_GET['with']) {
+            if (isset($_GET['with']) && $_GET['with']) {
                 sort($collections, SORT_STRING | SORT_FLAG_CASE);
                 echo ' (' . implode(" | ", $collections) . ')';
             }
@@ -228,7 +228,7 @@ if (!isset($_GET['format'])) {
         echo "</table>\n";
         echo "<hr/>\n";
         echo '<div>Bestand der UB Mannheim: E';
-        if ($_GET['with']) {
+        if (isset($_GET['with']) && $_GET['with']) {
             sort($collections, SORT_STRING | SORT_FLAG_CASE);
             echo ' (' . implode(" | ", $collections) . ')';
         }


### PR DESCRIPTION
Avoid a PHP warning about undefined array key.

isbn/suche.html logs a warning for every access, e.g.:
`PHP Warning:  Undefined array key "with" in /var/www/data/malibu-dev/isbn/man-sru.php on line 231, referer: https://data.bib.uni-mannheim.de/malibu-dev/isbn/suche.html?isbn=9783031871634`