### PR TITLE
Evalute 'with' parameter and avoid warning on missing array key

### DIFF
--- a/isbn/alma-sru.php
+++ b/isbn/alma-sru.php
@@ -269,7 +269,7 @@ if (!isset($_GET['format'])) {
         echo "</table>\n";
         echo "<hr/>\n";
         echo '<div>Bestand Alma-SRU: E';
-        if (isset($_GET['with']) && $_GET['with']) {
+        if (isset($_GET['with']) && $_GET['with']=="collections") {
             sort($collections, SORT_STRING | SORT_FLAG_CASE);
             echo ' (' . implode(" | ", $collections) . ')';
         }

--- a/isbn/man-sru.php
+++ b/isbn/man-sru.php
@@ -228,7 +228,7 @@ if (!isset($_GET['format'])) {
         echo "</table>\n";
         echo "<hr/>\n";
         echo '<div>Bestand der UB Mannheim: E';
-        if (isset($_GET['with']) && $_GET['with']) {
+        if (isset($_GET['with']) && $_GET['with']=="collections") {
             sort($collections, SORT_STRING | SORT_FLAG_CASE);
             echo ' (' . implode(" | ", $collections) . ')';
         }


### PR DESCRIPTION
Evalute parameter and avoid a PHP warning about undefined array key:
`PHP Warning:  Undefined array key "with" in /var/www/data/malibu-dev/isbn/man-sru.php on line 231, referer: https://data.bib.uni-mannheim.de/malibu-dev/isbn/suche.html?isbn=9783031871634`