### PR TITLE
Add the ability to auto-clear the ISBN search field. 

### DIFF
--- a/index.html
+++ b/index.html
@@ -47,6 +47,11 @@
 			<optgroup id="AT" label="Österreich" />
 			<optgroup id="CH" label="Schweiz" />
 			</select>
+			<br/>
+			<label style="cursor:pointer;">
+				<input type="checkbox" id="toggleClearIsbn" style="vertical-align:middle;" />
+				<span style="vertical-align:middle;">ISBN-Eingabe nach Laden leeren</span>
+			</label>
 		</form>
 		<p>Bei Auswahl eines anderen Verbundes und/oder Bibliothek ändert sich die URL um die entsprechenden Parameter hier.
 		Zudem berücksichtigen die ausgehenden Links dann auch diese Einstellungen (soweit relevant ist).</p>
@@ -106,6 +111,22 @@
 		
 		
 		<script type="text/javascript">
+			// Toggle for clearing ISBN input after page load
+			var clearIsbnKey = 'clearIsbnAfterLoad';
+			var $toggle = document.getElementById('toggleClearIsbn');
+			if ($toggle) {
+				// Default to true if not set
+				var stored = localStorage.getItem(clearIsbnKey);
+				var clearIsbn = (stored === null) ? true : (stored === 'true');
+				$toggle.checked = clearIsbn;
+				$toggle.addEventListener('change', function() {
+					localStorage.setItem(clearIsbnKey, this.checked);
+				});
+				// If not set, set to true in localStorage
+				if (stored === null) {
+					localStorage.setItem(clearIsbnKey, 'true');
+				}
+			}
 			var libraries;
 			fetch('./isbn/srulibraries.json')
 			  .then((response) => response.json())

--- a/isbn/suche.html
+++ b/isbn/suche.html
@@ -227,6 +227,9 @@ $(document).ready(function(){
 
    updateLinks();
 
+    // Read setting for clearing ISBN input after page load
+    var clearIsbnKey = 'clearIsbnAfterLoad';
+
 
     var meinVerbund = getParameterByName("verbund").toLowerCase() || "k10plus";
     document.querySelector("#selectPpn").value = meinVerbund;
@@ -235,6 +238,10 @@ $(document).ready(function(){
         $('#eingabeIsbn').val(getParameterByName("isbn"));
         $('#eingabePpn').val('');
         isbnEingabe(getParameterByName("isbn"));
+        // Clear the input after page load if toggle is enabled
+        if (localStorage.getItem(clearIsbnKey) === 'true') {
+            setTimeout(function() { $('#eingabeIsbn').val(''); }, 0);
+        }
     } else if (getParameterByName("ppn")) {
         $('#eingabePpn').val(getParameterByName("ppn"));
         $('#eingabeIsbn').val('');


### PR DESCRIPTION
Useful for when using scanners. That way one can simply scan each book one after the other without having to manually erase the field.